### PR TITLE
feat(docs): indicate library is ga

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -4,7 +4,7 @@
   "product_documentation": "https://cloud.google.com/solutions/talent-solution/",
   "client_documentation": "https://googleapis.dev/nodejs/talent/latest",
   "issue_tracker": "https://issuetracker.google.com/savedsearches/559664",
-  "release_level": "beta",
+  "release_level": "ga",
   "language": "nodejs",
   "repo": "googleapis/nodejs-talent",
   "distribution_name": "@google-cloud/talent",

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # [Google Cloud Talent Solution: Node.js Client](https://github.com/googleapis/nodejs-talent)
 
-[![release level](https://img.shields.io/badge/release%20level-beta-yellow.svg?style=flat)](https://cloud.google.com/terms/launch-stages)
+[![release level](https://img.shields.io/badge/release%20level-general%20availability%20%28GA%29-brightgreen.svg?style=flat)](https://cloud.google.com/terms/launch-stages)
 [![npm version](https://img.shields.io/npm/v/@google-cloud/talent.svg)](https://www.npmjs.org/package/@google-cloud/talent)
 [![codecov](https://img.shields.io/codecov/c/github/googleapis/nodejs-talent/master.svg?style=flat)](https://codecov.io/gh/googleapis/nodejs-talent)
 
@@ -87,11 +87,12 @@ _Legacy Node.js versions are supported as a best effort:_
 This library follows [Semantic Versioning](http://semver.org/).
 
 
+This library is considered to be **General Availability (GA)**. This means it
+is stable; the code surface will not change in backwards-incompatible ways
+unless absolutely necessary (e.g. because of critical security issues) or with
+an extensive deprecation period. Issues and requests against **GA** libraries
+are addressed with the highest priority.
 
-This library is considered to be in **beta**. This means it is expected to be
-mostly stable while we work toward a general availability release; however,
-complete stability is not guaranteed. We will address issues and requests
-against beta libraries with a high priority.
 
 
 


### PR DESCRIPTION
Library hasn't had any major breaking changes for 28 days, and has a stable API surface.